### PR TITLE
The /etc/postfix directory needs to be owned by the postfix user

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -6,3 +6,7 @@
       - postfix
       - ca-certificates
       - mailutils
+
+- name: Ensure /etc/postfix directory is owned by postfix user
+  file: path=/etc/postfix owner=postfix
+  notify: postfix restart


### PR DESCRIPTION
Fixes #2.

There's currently a bug in Ubuntu 12.04 TLS where the /etc/postfix
directory is owned by root and postfix has an issue creating the
sasl_passwd.db when postfix_smtp_sasl_auth_enable option is enabled.
