### PR TITLE
Fix sender rewrite and local account forward

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -29,6 +29,11 @@
   command: /usr/sbin/postmap /etc/postfix/generic
   when: _postfix_generic is defined and _postfix_generic.changed
 
+- name: Configure postfix local user relay
+  template: src=virtual.j2 dest=/etc/postfix/virtual-pcre owner=root group=root mode=0644
+  notify: postfix restart
+  when: postfix_local_user_relay_address != ""
+
 - name: Configure postfix sender canonical maps
   template: src=sender_canonical_maps.j2 dest=/etc/postfix/sender_canonical_maps
   when: postfix_rewrite_sender_address != ""

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -33,6 +33,7 @@ mydestination = {{postfix_mydestination}}
 # Relay all local mail to a specific address
 luser_relay = {{ postfix_local_user_relay_address }}
 local_recipient_maps =
+virtual_alias_maps = pcre:/etc/postfix/virtual-pcre
 {% endif %}
 
 {% if postfix_smtp_sasl_auth_enable %}

--- a/templates/virtual.j2
+++ b/templates/virtual.j2
@@ -1,0 +1,1 @@
+/.+@localhost/ {{postfix_local_user_relay_address}}


### PR DESCRIPTION
Two fixes related to my previous PR #1.

See commit messages, sender rewriting got broken with 5cb524571407d7ae6148184eb3e74687a1e55f41.
