### PR TITLE
Lock down permissions on the SASL password file

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -12,7 +12,7 @@
     - master.cf
 
 - name: Configure postfix pt. 2
-  template: src=sasl_passwd.j2 dest=/etc/postfix/sasl_passwd owner=root group=root mode=0644
+  template: src=sasl_passwd.j2 dest=/etc/postfix/sasl_passwd owner=root group=root mode=0600
   register: _postfix_sasl_passwd
   notify: postfix restart
 


### PR DESCRIPTION
I don't want every user account on the box (including www-data, nobody,
or user accounts), to be able to read the plain-text password in the
password file. Only let root have access to the password.

See http://postfix.state-of-mind.de/patrick.koetter/smtpauth/smtp_auth_mailservers.html
for more detail.

(When sasl_passwd.db is built from sasl_passwd by /usr/sbin/postmap, the
new .db file takes on the permissions of the base file by default. So we
don't need to explicitly set the permissions of sasl_passwd.db)