### PR TITLE
Added option to choose if you want smtp tls to be enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - pip install ansible>=1.6.0
 script:
   # Prepare tests
-  - echo localhost > inventory
+  - echo localhost ansible_connection=local > inventory
 
   # Check syntax
   - ansible-playbook --syntax-check -i inventory test.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - pip install ansible>=1.6.0
 script:
   # Prepare tests
-  - echo localhost ansible_connection=local > inventory
+  - echo localhost > inventory
 
   # Check syntax
   - ansible-playbook --syntax-check -i inventory test.yml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ postfix_myhostname: "{{inventory_hostname}}"
 postfix_myorigin: $myhostname
 postfix_smtp_sasl_auth_enable: yes
 postfix_smtp_tls_cafile: "/etc/ssl/certs/Thawte_Premium_Server_CA.pem"
+postfix_smtp_use_tls: yes
 postfix_relayhost:
 postfix_mynetworks: "127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128"
 postfix_inet_interfaces: loopback-only

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -44,9 +44,11 @@ local_recipient_maps = {{ postfix_local_recipient_map }}
 smtp_sasl_auth_enable = yes
 smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
 smtp_sasl_security_options =
+{% if postfix_smtp_use_tls %}
 smtp_use_tls = yes
 smtp_tls_security_level = encrypt
 smtp_tls_CAfile = {{ postfix_smtp_tls_cafile }}
+{% endif %}
 {% endif %}
 
 {% if postfix_relayhost %}

--- a/test.yml
+++ b/test.yml
@@ -1,4 +1,6 @@
 - hosts: all
+  vars:
+    - ansible_ssh_user: root
   tasks:
     - include: tasks/main.yml
   handlers:


### PR DESCRIPTION
The SMTP provider we use doesn't have TLS enabled on some enviroments, so I've included the ability to specify if you want SMTP TLS enabled or disabled.

By default `smtp_use_tls` is enabled so this change will be back compatible with how it's set up at the moment.