### PR TITLE
using smtp_tls_CApath instead of smtp_tls_CAfile

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ postfix_smtpd_use_tls: yes
 postfix_myhostname: "{{inventory_hostname}}"
 postfix_myorigin: $myhostname
 postfix_smtp_sasl_auth_enable: yes
-postfix_smtp_tls_cafile: "/etc/ssl/certs/Thawte_Premium_Server_CA.pem"
+postfix_smtp_tls_CApath: "/etc/ssl/certs"
 postfix_smtp_use_tls: yes
 postfix_relayhost:
 postfix_mynetworks: "127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128"

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -47,7 +47,7 @@ smtp_sasl_security_options =
 {% if postfix_smtp_use_tls %}
 smtp_use_tls = yes
 smtp_tls_security_level = encrypt
-smtp_tls_CAfile = {{ postfix_smtp_tls_cafile }}
+smtp_tls_CApath = {{postfix_smtp_tls_CApath}} 
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
on Ubuntu 14.04 "/etc/ssl/certs/Thawte_Premium_Server_CA.pem" doesn't exists