### PR TITLE
FIX #11 - AWS SES and others as relayhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ postfix_mynetworks: "127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128"
 postfix_inet_interfaces: loopback-only
 postfix_mydestination: $mydomain, $myhostname, localhost.$mydomain, localhost
 postfix_local_recipient_map: ""
+postfix_smtp_sasl_security_options: ""
 
 postfix_generic_maps: ""
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ postfix_mynetworks: "127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128"
 postfix_inet_interfaces: loopback-only
 postfix_mydestination: $mydomain, $myhostname, localhost.$mydomain, localhost
 postfix_local_recipient_map: ""
+postfix_smtp_sasl_security_options: ""
 
 postfix_generic_maps: ""
 

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -6,6 +6,7 @@
   - postfix
   - ca-certificates
   - mailutils
+  - libsasl2-modules
 
 - name: Install DKIM requirements (Debian)
   apt: name={{item}}

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -43,7 +43,7 @@ local_recipient_maps = {{ postfix_local_recipient_map }}
 {% if postfix_smtp_sasl_auth_enable %}
 smtp_sasl_auth_enable = yes
 smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
-smtp_sasl_security_options =
+smtp_sasl_security_options = {{ postfix_smtp_sasl_security_options }}
 {% if postfix_smtp_use_tls %}
 smtp_use_tls = yes
 smtp_tls_security_level = encrypt


### PR DESCRIPTION
adds an module required for sasl auth on Debian 8 and an option which is required for ex.: SES to set to nonanonymous
