### PR TITLE
Added default for ansible_ssh_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ postfix_rewrite_sender_address: ""
 # Send a test mail to this address when Postfix configuration changes
 postfix_send_test_mail_to: ""
 
-postfix_smtp_sasl_user: "{{ansible_ssh_user}}"
+postfix_smtp_sasl_user: "{{ansible_ssh_user|default('root')}}"
 postfix_smtp_sasl_password: ""
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ postfix_rewrite_sender_address: ""
 # Send a test mail to this address when Postfix configuration changes
 postfix_send_test_mail_to: ""
 
-postfix_smtp_sasl_user: "{{ansible_ssh_user}}"
+postfix_smtp_sasl_user: "{{ansible_ssh_user|default('root')}}"
 postfix_smtp_sasl_password: ""
 
 # Queue


### PR DESCRIPTION
Since ansible 2.1 `ansible_ssh_user` may be undefined if `ansible-playbook` is launched without the `-u` option and if `ansible_ssh_user` is not defined anywhere else (eg: in the inventory), in order to avoid this failure we can add a default placeholder value.