### PR TITLE
Use ansible_distribution instead of hardcoding Ubuntu in banner

### DIFF
--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -3,7 +3,7 @@
 
 # See /usr/share/postfix/main.cf.dist for a commented, more complete version
 
-smtpd_banner = $myhostname ESMTP $mail_name (Ubuntu)
+smtpd_banner = $myhostname ESMTP $mail_name ({{ ansible_distribution }})
 biff = no
 
 # appending .domain is the MUA's job


### PR DESCRIPTION
Hi... I just noticed that postfix was announcing that my RHEL boxes were Ubuntu.  This should fix.

Thanks!
