### PR TITLE
Bugfix -- enable postfix service in systemd

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -47,5 +47,3 @@
   template: src=systemd.service dest=/etc/systemd/system/postfix.service mode=0755
   when: postfix_os_service == 'systemd'
   notify: postfix restart
-
-- service: name=postfix state=started enabled=yes

--- a/tasks/postfix.yml
+++ b/tasks/postfix.yml
@@ -14,5 +14,9 @@
 
 - include: configure.yml
 
+- name: Ensure Postfix service is enabled (systemd)
+  service: name=postfix enabled=yes use=service
+  when: postfix_os_service == 'systemd'
+
 - name: Ensure Postfix is started
   service: name=postfix state=started enabled=yes


### PR DESCRIPTION
Now Postfix is not enabled in systemd :(

Related topic:
https://github.com/ansible/ansible-modules-core/issues/3764

Magic, that works is add "use=system" to service command.
I've tested on ubuntu 16.04 with systemd — it works.