### PR TITLE
Improved support for Fedora

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,3 +48,5 @@ postfix_tls_generate: False
 postfix_ssl_subject: ""
 postfix_tls_cert_file: "/etc/ssl/certs/ssl-cert-snakeoil.pem"
 postfix_tls_key_file: "/etc/ssl/private/ssl-cert-snakeoil.key"
+
+postfix_postalias: "{% if ansible_os_family == 'Debian' %}/usr/sbin/postaliases{% else %}/usr/sbin/postalias{% endif %}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -31,7 +31,9 @@
   when: _postfix_generic is defined and _postfix_generic.changed
 
 - name: Configure postfix pt. 6
-  command: /usr/sbin/postaliases /etc/aliases creates=/etc/aliases.db
+  command: "{{ postfix_postalias }} /etc/aliases"
+  args:
+    creates: /etc/aliases.db
 
 - name: Configure postfix local user relay
   template: src=virtual.j2 dest=/etc/postfix/virtual-pcre owner=root group=root mode=0644

--- a/tasks/install.yum.yml
+++ b/tasks/install.yum.yml
@@ -1,12 +1,13 @@
 ---
 
 - name: Install requirements (RedHat)
-  yum: name={{item}}
+  package: name={{item}}
   with_items:
   - postfix
   - ca-certificates
   - mailx
+  - libselinux-python
 
 - name: Install DKIM requirements (RedHat)
-  yum: name=opendkim
+  package: name=opendkim
   when: postfix_dkim


### PR DESCRIPTION
This patch improves support for RedHat based systems as there are minor differences in the name of some configuration files and packages required to run the role smoothly.

We are using this in [ansible-openwisp2](https://github.com/openwisp/ansible-openwisp2).